### PR TITLE
Add support for string-keyed `attrs` in `from` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,12 @@ unless defaulted or provided as attributes to the constructor.
     }
   ```
 
+## String keyed attributes
+The attributes map provided to the constructor functions can be either string-keyed or atom-key, not mixed.
+
+Under the covers we are using [Ecto.Changeset.cast/4](https://hexdocs.pm/ecto/Ecto.Changeset.html#cast/4), to
+copy and cast attributes into the struct being created.  
+
 ## Installation
 Because this plugin supports the interface defined by the `TypedStruct` macro, installation assumes you've already
 added that dependency.

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,7 @@ defmodule TypedStructCtor.MixProject do
   defp package() do
     [
       licenses: ["MIT"],
-      links: %{"Github" => "https://github.com/withbelay/typed_struct_ctor"}
+      links: %{"Github" => "https://github.com/leggebroten/typed_struct_ctor"}
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule TypedStructCtor.MixProject do
   def project do
     [
       app: :typed_struct_ctor,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -42,7 +42,7 @@ defmodule TypedStructCtor.MixProject do
   defp deps do
     [
       {:credo, "~> 1.7", only: [:dev, :test]},
-      {:dialyxir, "~> 1.3", only: [:dev, :test]},
+      {:dialyxir, "~> 1.3", only: [:dev, :test], runtime: false},
       {:ecto, "~> 3.10"},
       {:ex_doc, "~> 0.30", only: :dev},
       {:typedstruct, "~> 0.5.2"},


### PR DESCRIPTION
Add support for string-keyed `attrs` in `from` functions

Since we're using Ecto.Changeset.cast, `new` already supported `attrs` being string-keyed as the `cast` function accepts either atom or string keyed maps and appropriately sets the struct fields.

However, the original `from` function did a simple `Map.merge` of the given `attrs`.  This resulted in a mix-key map being given to the `new` function.
 
Alter the `from` function to cast attrs to get an atom-keyed map of attributes which then merged as normal with the original `base_struct`